### PR TITLE
Github actions  trigger on pushes to main

### DIFF
--- a/.github/workflows/move-into-oss.yml
+++ b/.github/workflows/move-into-oss.yml
@@ -3,7 +3,7 @@ name: Displaying jekyll in Docusaurus
 on:
   push:
     branches:
-      - github-actions
+      - main
 
 jobs:
   changed_files:


### PR DESCRIPTION
Replacin the trigger for the GH actions to be on main instead of this branch 